### PR TITLE
Fix compiler warnings

### DIFF
--- a/config.c
+++ b/config.c
@@ -5,22 +5,6 @@
 
 #include "config.h"
 
-typedef struct ini_entry_s {
-    char* key;
-    char* value;
-} ini_entry_s;
-
-typedef struct ini_section_s {
-    char* name;
-    ini_entry_s* entry;
-    int size;
-} ini_section_s;
-
-typedef struct ini_table_s {
-    ini_section_s* section;
-    int size;
-} ini_table_s;
-
 void print_log(int line, const char* msg, const char* extra)
 {
     printf("TConfig [Line: %i]: ", line);
@@ -121,7 +105,7 @@ bool ini_table_read_from_file(ini_table_s* table, const char* file)
     FILE* f = fopen(file, "r");
     if (f == NULL) return false;
 
-    enum {Section, Key, Value, Comment} state;
+    enum {Section, Key, Value, Comment} state = Section;
     int   c;
     int   position = 0;
     int   spaces   = 0;
@@ -157,7 +141,9 @@ bool ini_table_read_from_file(ini_table_s* table, const char* file)
                        if (c != EOF && c != '\n') buf[position++] = c;
                     }
                 }
+            // fallthrough
             case '\n':
+            // fallthrough
             case EOF:
                 line++;
                 if (state == Value) {

--- a/config.h
+++ b/config.h
@@ -2,7 +2,21 @@
 #define _TCONFIG_H_
 #include <stdbool.h>
 
-typedef struct ini_table_s ini_table_s;
+typedef struct ini_entry_s {
+    char* key;
+    char* value;
+} ini_entry_s;
+
+typedef struct ini_section_s {
+    char* name;
+    ini_entry_s* entry;
+    int size;
+} ini_section_s;
+
+typedef struct ini_table_s {
+    ini_section_s* section;
+    int size;
+} ini_table_s;
 
 /**
  * @brief Creates an empty ini_table_s struct for writing new entries to.


### PR DESCRIPTION
This silences the majority of warnings when compiled using -std=c99 -Wall -Wextra -pedantic.
Using the // fallthrough tag on its own line is required when implicit fallthrough is being used. The state enum was also being used uninitialised. Additionally, there was a redefinition of ini_table_s, so I moved all of the typedefs into the header.

There is still one more warning left. The strcasecmp function is being used without including strings.h, a header that is different from string.h. The strcasecmp function is not a part of the C standard, so you have the option of changing ini_table_get_entry_as_bool to use tolower on every character being compared, or including strings.h and defining _POSIX_C_SOURCE 200112L. I did not make this choice for you, as I don't actually need this function in my projects, and therefore simply fixed it by using strcmp instead.